### PR TITLE
Initialize Next.js portfolio site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+out

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# sadia
-Portfolio website 
+# Portfolio
+
+An elegant portfolio website built with Next.js, Tailwind CSS, and Framer Motion.
+
+## Development
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the development server:
+
+```bash
+npm run dev
+```
+
+## Deployment
+
+`npm run build` creates a static export in `out/` suitable for GitHub Pages. A GitHub Actions workflow deploys the site on pushes to `main`.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export'
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "portfolio",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build && next export",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "framer-motion": "^11.0.0",
+    "next": "^14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,0 +1,14 @@
+import './globals.css';
+
+export const metadata = {
+  title: "My Love's Portfolio",
+  description: 'An elegant showcase.',
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body className="bg-white text-gray-900">{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,0 +1,17 @@
+import Hero from '../components/Hero';
+import Projects from '../components/Projects';
+import Skills from '../components/Skills';
+import Experience from '../components/Experience';
+import Contact from '../components/Contact';
+
+export default function Home() {
+  return (
+    <main>
+      <Hero />
+      <Projects />
+      <Skills />
+      <Experience />
+      <Contact />
+    </main>
+  );
+}

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -1,0 +1,31 @@
+'use client';
+
+export default function Contact() {
+  return (
+    <section className="py-20" id="contact">
+      <h2 className="text-3xl font-semibold text-center mb-10">Contact</h2>
+      <form
+        action="https://formspree.io/f/mayvlzwn"
+        method="POST"
+        className="max-w-md mx-auto flex flex-col gap-4"
+      >
+        <input
+          type="email"
+          name="_replyto"
+          placeholder="Your email"
+          className="border p-2 rounded"
+          required
+        />
+        <textarea
+          name="message"
+          placeholder="Your message"
+          className="border p-2 rounded h-32"
+          required
+        />
+        <button type="submit" className="bg-black text-white py-2 rounded">
+          Send
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/components/Experience.js
+++ b/src/components/Experience.js
@@ -1,0 +1,31 @@
+'use client';
+import { motion } from 'framer-motion';
+
+const experiences = [
+  { year: '2021', detail: 'Joined Company A as Developer.' },
+  { year: '2022', detail: 'Promoted to Senior Developer at Company A.' },
+  { year: '2023', detail: 'Started freelancing and building love-filled projects.' },
+];
+
+export default function Experience() {
+  return (
+    <section className="py-20 bg-gray-50" id="experience">
+      <h2 className="text-3xl font-semibold text-center mb-10">Experience</h2>
+      <div className="max-w-3xl mx-auto">
+        {experiences.map((exp, idx) => (
+          <motion.div
+            key={exp.year}
+            initial={{ opacity: 0, x: -20 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: idx * 0.2 }}
+            className="mb-8"
+          >
+            <h3 className="font-bold">{exp.year}</h3>
+            <p className="ml-4">{exp.detail}</p>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -1,0 +1,25 @@
+'use client';
+import { motion } from 'framer-motion';
+
+export default function Hero() {
+  return (
+    <section className="min-h-screen flex flex-col justify-center items-center text-center">
+      <motion.h1
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 1 }}
+        className="text-4xl md:text-6xl font-bold mb-4"
+      >
+        To My Soulmate
+      </motion.h1>
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.5 }}
+        className="max-w-xl"
+      >
+        A portfolio crafted with love and elegance.
+      </motion.p>
+    </section>
+  );
+}

--- a/src/components/Projects.js
+++ b/src/components/Projects.js
@@ -1,0 +1,31 @@
+'use client';
+import { motion } from 'framer-motion';
+
+const projects = [
+  { title: 'Project One', description: 'Description of project one.' },
+  { title: 'Project Two', description: 'Description of project two.' },
+  { title: 'Project Three', description: 'Description of project three.' },
+];
+
+export default function Projects() {
+  return (
+    <section className="py-20 bg-gray-50" id="projects">
+      <h2 className="text-3xl font-semibold text-center mb-10">Projects</h2>
+      <div className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto">
+        {projects.map((p, idx) => (
+          <motion.div
+            key={p.title}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: idx * 0.2 }}
+            className="p-6 rounded-lg shadow bg-white"
+          >
+            <h3 className="font-bold text-xl mb-2">{p.title}</h3>
+            <p>{p.description}</p>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/Skills.js
+++ b/src/components/Skills.js
@@ -1,0 +1,26 @@
+'use client';
+import { motion } from 'framer-motion';
+
+const skills = ['JavaScript', 'React', 'Next.js', 'Tailwind CSS'];
+
+export default function Skills() {
+  return (
+    <section className="py-20" id="skills">
+      <h2 className="text-3xl font-semibold text-center mb-10">Skills</h2>
+      <div className="flex flex-wrap justify-center gap-4">
+        {skills.map((s, idx) => (
+          <motion.span
+            key={s}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: idx * 0.1 }}
+            className="px-4 py-2 bg-gray-200 rounded-full"
+          >
+            {s}
+          </motion.span>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js portfolio with Tailwind CSS and Framer Motion components
- add sections for hero, projects, skills, experience, and contact form
- configure static export and GitHub Pages deployment workflow

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b026e39e60832390b3eec43147ada4