### PR TITLE
chore: drop deprecated next export

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && next export",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "test": "echo \"No tests\""


### PR DESCRIPTION
## Summary
- simplify build script now that Next.js static export is configured in next.config.js

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b030eb9e3c8323b48af29d4fcd49e0