### PR TITLE
Fix GitHub Actions workflow without lock file

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -52,7 +52,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:


### PR DESCRIPTION
## Summary
- remove dependency cache parameter from the `setup-node` step so the workflow succeeds without a lock file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b032025158832398e0377c1cd27500