### PR TITLE
Add navigation bar and portfolio details

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,4 +1,5 @@
 import './globals.css';
+import Navbar from '../components/Navbar';
 
 export const metadata = {
   title: "My Love's Portfolio",
@@ -8,7 +9,10 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className="bg-white text-gray-900">{children}</body>
+      <body className="bg-white text-gray-900">
+        <Navbar />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -4,6 +4,11 @@ export default function Contact() {
   return (
     <section className="py-20" id="contact">
       <h2 className="text-3xl font-semibold text-center mb-10">Contact</h2>
+      <div className="max-w-md mx-auto text-center mb-8 space-y-2">
+        <p>📍 Islamabad, Pakistan</p>
+        <p>📞 +92 318 7428793</p>
+        <p>✉️ Sadiasl725@gmail.com</p>
+      </div>
       <form
         action="https://formspree.io/f/mayvlzwn"
         method="POST"

--- a/src/components/Experience.js
+++ b/src/components/Experience.js
@@ -2,9 +2,21 @@
 import { motion } from 'framer-motion';
 
 const experiences = [
-  { year: '2021', detail: 'Joined Company A as Developer.' },
-  { year: '2022', detail: 'Promoted to Senior Developer at Company A.' },
-  { year: '2023', detail: 'Started freelancing and building love-filled projects.' },
+  {
+    year: '2017 - Present',
+    detail:
+      'Freelance Graphic Designer & Illustrator on Fiverr, Upwork, and Freelancer.',
+  },
+  {
+    year: '2015 - 2019',
+    detail:
+      "Bachelor's in Product & Industrial Design, University of Engineering & Technology, Lahore.",
+  },
+  {
+    year: 'Achievements',
+    detail:
+      'Top 10% globally for Adobe Photoshop & Illustrator; featured designer for bestselling authors.',
+  },
 ];
 
 export default function Experience() {

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -3,14 +3,17 @@ import { motion } from 'framer-motion';
 
 export default function Hero() {
   return (
-    <section className="min-h-screen flex flex-col justify-center items-center text-center">
+    <section
+      id="home"
+      className="min-h-screen flex flex-col justify-center items-center text-center"
+    >
       <motion.h1
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 1 }}
         className="text-4xl md:text-6xl font-bold mb-4"
       >
-        To My Soulmate
+        SADIA SHAHID | GRAPHIC ARTIST
       </motion.h1>
       <motion.p
         initial={{ opacity: 0 }}
@@ -18,7 +21,7 @@ export default function Hero() {
         transition={{ delay: 0.5 }}
         className="max-w-xl"
       >
-        A portfolio crafted with love and elegance.
+        Award-winning Graphic Designer and Illustrator with 8+ years of experience crafting high-impact visuals.
       </motion.p>
     </section>
   );

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,0 +1,23 @@
+'use client';
+import Link from 'next/link';
+
+export default function Navbar() {
+  return (
+    <nav className="flex justify-between items-center p-4 shadow-md bg-white sticky top-0 z-10">
+      <div className="flex space-x-4">
+        <Link href="#home" className="hover:text-gray-600">Home</Link>
+        <Link href="#projects" className="hover:text-gray-600">Projects</Link>
+        <Link href="#skills" className="hover:text-gray-600">Skills</Link>
+        <Link href="#contact" className="hover:text-gray-600">Contact</Link>
+      </div>
+      <div className="flex items-center space-x-4">
+        <div className="flex space-x-2 text-xl">
+          <a href="https://instagram.com/SadiaShahid" aria-label="Instagram">📷</a>
+          <a href="https://twitter.com/SadiaShahid" aria-label="Twitter">🐦</a>
+          <a href="https://www.linkedin.com/in/SadiaShahid" aria-label="LinkedIn">💼</a>
+        </div>
+        <span className="font-bold">Sadia Shahid</span>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/Projects.js
+++ b/src/components/Projects.js
@@ -2,9 +2,34 @@
 import { motion } from 'framer-motion';
 
 const projects = [
-  { title: 'Project One', description: 'Description of project one.' },
-  { title: 'Project Two', description: 'Description of project two.' },
-  { title: 'Project Three', description: 'Description of project three.' },
+  {
+    title: 'Driftwood Brew',
+    description:
+      'Brand identity for a cozy, artisanal coffee shop. Tagline: Drift, Sip, Savor.',
+    tools: ['Ps', 'Ai'],
+    socials: ['📷', '🐦'],
+  },
+  {
+    title: 'Terravia',
+    description:
+      'Eco-friendly travel brand inviting explorers to connect with nature and travel sustainably.',
+    tools: ['Ps', 'Ai'],
+    socials: ['📷', '🐦'],
+  },
+  {
+    title: 'NeoHerb Skincare',
+    description:
+      'Nature-inspired skincare line that revitalizes skin with pure, herbal ingredients.',
+    tools: ['Ps', 'Ai'],
+    socials: ['📷', '🐦'],
+  },
+  {
+    title: 'CoolHouse',
+    description:
+      'Social media campaign and branding assets for lifestyle platform CoolHouse.',
+    tools: ['Ps', 'Ai'],
+    socials: ['📷', '🐦'],
+  },
 ];
 
 export default function Projects() {
@@ -23,6 +48,25 @@ export default function Projects() {
           >
             <h3 className="font-bold text-xl mb-2">{p.title}</h3>
             <p>{p.description}</p>
+            {p.tools && (
+              <div className="flex space-x-2 mt-4">
+                {p.tools.map((t) => (
+                  <span
+                    key={t}
+                    className="px-2 py-1 bg-gray-200 rounded text-sm font-semibold"
+                  >
+                    {t}
+                  </span>
+                ))}
+              </div>
+            )}
+            {p.socials && (
+              <div className="flex space-x-2 mt-4 text-xl">
+                {p.socials.map((s, i) => (
+                  <span key={i}>{s}</span>
+                ))}
+              </div>
+            )}
           </motion.div>
         ))}
       </div>

--- a/src/components/Skills.js
+++ b/src/components/Skills.js
@@ -1,7 +1,14 @@
 'use client';
 import { motion } from 'framer-motion';
 
-const skills = ['JavaScript', 'React', 'Next.js', 'Tailwind CSS'];
+const skills = [
+  'Adobe Photoshop',
+  'Adobe Illustrator',
+  '3D Visualization',
+  'Motion Graphics',
+  'UI/UX',
+  'Branding Strategy',
+];
 
 export default function Skills() {
   return (


### PR DESCRIPTION
## Summary
- add sticky navbar with section links, social links, and Sadia's name
- update hero, projects, experience, skills, and contact sections with provided portfolio information

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b03ef6e70c83238744055c0364b153